### PR TITLE
Initialize 'report' var inside button click function

### DIFF
--- a/internal/desktopApp/desktopApp.go
+++ b/internal/desktopApp/desktopApp.go
@@ -87,13 +87,13 @@ func getCNameRecords(w fyne.Window) {
 	placeholder.Hide()
 
 	subdomains := []string{"autodiscover", "lyncdiscover", "selector1._domainkey", "selector2._domainkey"}
-	report := "" // Initialize the report string here
 
 	w.SetContent(container.NewVBox(
 		warning,
 		inputDomain,
 		placeholder,
 		widget.NewButton("Prüfen", func() {
+			report := "" // Initialize the report string here
 			for _, subdomain := range subdomains {
 				FullDomain := fmt.Sprintf("%s.%s", subdomain, inputDomain.Text)
 				report += fmt.Sprintf("Domain: %s\n", FullDomain)


### PR DESCRIPTION
Moved the initialization of 'report' string inside the 'Prüfen' button's function. This ensures that the report is cleared each time the button is pressed, providing a fresh start for each new domain check completion.