### PR TITLE
Refactored main.go to only run desktopApp

### DIFF
--- a/cmd/Go-DNS/main.go
+++ b/cmd/Go-DNS/main.go
@@ -1,31 +1,9 @@
 package main
 
 import (
-	"flag"
 	"github.com/hra42/Go-DNS/internal/desktopApp"
-	"github.com/hra42/Go-DNS/internal/dns"
 )
 
 func main() {
-	domain := flag.String("domain", "", "Domain to query")
-	mx := flag.Bool("mx", false, "Get MX records for a domain")
-	cname := flag.Bool("cname", false, "Get CNAME records for a domain")
-	txt := flag.Bool("txt", false, "Get TXT records for a domain")
-	all := flag.Bool("all", false, "Get all records for a domain")
-	flag.Parse()
-
-	switch true {
-	case *mx == true:
-		dns.PrintMXRecords(*domain)
-	case *all == true:
-		dns.PrintMXRecords(*domain)
-		dns.PrintCNameRecords(*domain)
-		dns.PrintTXTRecords(*domain)
-	case *cname == true:
-		dns.PrintCNameRecords(*domain)
-	case *txt == true:
-		dns.PrintTXTRecords(*domain)
-	default:
-		desktopApp.RunDesktop()
-	}
+	desktopApp.RunDesktop()
 }

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -1,7 +1,6 @@
 package dns
 
 import (
-	"fmt"
 	"github.com/miekg/dns"
 	"log"
 	"net"
@@ -82,67 +81,4 @@ func GetTXTRecords(domain string, dnsServer net.IP) []string {
 		}
 	}
 	return txtRecords
-}
-
-func PrintMXRecords(domain string) {
-	fmt.Printf("Domain: %s\n", domain)
-	for dnsServerName, dnsServerIP := range GetDNSServers() {
-		MXRecords := GetMXRecords(domain, dnsServerIP)
-
-		fmt.Printf("DNS server provider: %s\nIP: %s\n", dnsServerName, dnsServerIP)
-		if len(MXRecords) == 0 {
-			fmt.Printf("No MX records found for %s\n", domain)
-		} else {
-			for _, record := range MXRecords {
-				fmt.Printf("MX for record: %v\n", record)
-			}
-		}
-	}
-	fmt.Println("------------------------------------")
-}
-
-func PrintTXTRecords(domain string) {
-	fmt.Printf("Domain: %s\n", domain)
-	for dnsServerName, dnsServerIP := range GetDNSServers() {
-		TXTRecords := GetTXTRecords(domain, dnsServerIP)
-		fmt.Printf("DNS server provider: %s\nIP: %s\n", dnsServerName, dnsServerIP)
-		if len(TXTRecords) == 0 {
-			fmt.Printf("No TXT records found for %s\n", domain)
-		} else {
-			for _, record := range TXTRecords {
-				if record == "" {
-					fmt.Printf("No TXT records found for %s\n", domain)
-					break
-				} else {
-					fmt.Printf("TXT for record: %v\n", record)
-				}
-			}
-		}
-	}
-	fmt.Println("------------------------------------")
-}
-
-func PrintCNameRecords(domain string) {
-	subdomains := []string{"autodiscover", "lyncdiscover", "selector1._domainkey", "selector2._domainkey"}
-	for _, subdomain := range subdomains {
-		FullDomain := fmt.Sprintf("%s.%s", subdomain, domain)
-		fmt.Printf("Domain: %s\n", FullDomain)
-		for dnsServerName, dnsServerIP := range GetDNSServers() {
-			CnameRecordsFullDomain := GetCNameRecords(FullDomain, dnsServerIP)
-			fmt.Printf("DNS server provider: %s\nIP: %s\n", dnsServerName, dnsServerIP)
-			if len(CnameRecordsFullDomain) == 0 {
-				fmt.Printf("No CNAME records found for %s\n", FullDomain)
-			} else {
-				for _, record := range CnameRecordsFullDomain {
-					if record == "" {
-						fmt.Printf("No CNAME records found for %s\n", FullDomain)
-						break
-					} else {
-						fmt.Printf("CNAME record for %v: %v\n", FullDomain, record)
-					}
-				}
-			}
-		}
-		fmt.Println("------------------------------------")
-	}
 }


### PR DESCRIPTION
Removed unused imports as part of the cleanup within the main.go file. The DNS querying functionality (i.e., domain, mx, cname, txt, etc.) has been removed as it was decided this will be handled directly within the desktopApp. Thus, the main.go function is streamlined to only run the desktopApp and removed the flags that were no longer needed.

Adjustments were also made to dns.go where several DNS record print functions were removed since they are now obsolete and are expected to be managed within the desktopApp itself.