### PR TITLE
Implement catppuccin theme and remove deprecated functions

### DIFF
--- a/internal/desktopApp/desktopApp.go
+++ b/internal/desktopApp/desktopApp.go
@@ -14,10 +14,126 @@ import (
 	"log"
 )
 
+type catppuccinTheme struct{}
+
+func (c catppuccinTheme) Color(name fyne.ThemeColorName, variant fyne.ThemeVariant) color.Color {
+	switch name {
+	case theme.ColorNameBackground:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Base())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Base())
+		}
+	case theme.ColorNamePlaceHolder:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Text())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Blue())
+		}
+	case theme.ColorNameInputBackground:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Base())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Base())
+		}
+	case theme.ColorNameSeparator:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Red())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Red())
+		}
+	case theme.ColorNamePrimary:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Subtext0())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Subtext0())
+		}
+	case theme.ColorNameSuccess:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Blue())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Blue())
+		}
+	case theme.ColorNameButton:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Surface0())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Surface0())
+		}
+	case theme.ColorNameMenuBackground:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Surface1())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Surface1())
+		}
+	case theme.ColorNameHover:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Surface2())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Surface2())
+		}
+	case theme.ColorNameError:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Red())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Red())
+		}
+	case theme.ColorNameSelection:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Lavender())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Lavender())
+		}
+	case theme.ColorNameDisabled:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Crust())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Crust())
+		}
+	case theme.ColorNameFocus:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Lavender())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Lavender())
+		}
+	default:
+		if variant == theme.VariantLight {
+			return getCatppucinColor(catppuccin.Latte.Text())
+		} else {
+			return getCatppucinColor(catppuccin.Mocha.Text())
+		}
+	}
+}
+
+func (c catppuccinTheme) Icon(name fyne.ThemeIconName) fyne.Resource {
+	return theme.DefaultTheme().Icon(name)
+}
+
+func (c catppuccinTheme) Font(style fyne.TextStyle) fyne.Resource {
+	return theme.DefaultTheme().Font(style)
+}
+
+func (c catppuccinTheme) Size(name fyne.ThemeSizeName) float32 {
+	return theme.DefaultTheme().Size(name)
+}
+
+type forceVariantTheme struct {
+	fyne.Theme
+
+	variant fyne.ThemeVariant
+}
+
+func (f *forceVariantTheme) Color(name fyne.ThemeColorName, _ fyne.ThemeVariant) color.Color {
+	return f.Theme.Color(name, f.variant)
+}
+
 func RunDesktop() {
 	// create a new app and window
 	a := app.New()
 	w := a.NewWindow("Go-DNS")
+
+	// set the default theme to latte or mocha
+	a.Settings().SetTheme(&catppuccinTheme{})
 
 	// set the icon from cloudflare r2 bucket
 	resourceIconPng, err := fyne.LoadResourceFromURLString("https://gpt-files.postrausch.tech/go-dns.png")
@@ -34,28 +150,27 @@ func RunDesktop() {
 	dnsRecords := fyne.NewMenu(
 		"DNS Records",
 		fyne.NewMenuItem("CNAME", func() {
-			getCNameRecords(w)
+			getCNameRecords(a, w)
 		}),
 		fyne.NewMenuItem("MX", func() {
-			getMX(w)
+			getMX(a, w)
 		}),
 		fyne.NewMenuItem("SSL Checker", func() {
-			checkSSL(w)
+			checkSSL(a, w)
 		}),
 		fyne.NewMenuItem("TXT", func() {
-			getTXT(w)
+			getTXT(a, w)
 		}),
 	)
 
-	// theme menu
+	// theme menu – override the default theme
 	themeSwitcher := fyne.NewMenu(
 		"Theme",
-		// TODO: replace this with a function that is not deprecated & define catppuccin theme
 		fyne.NewMenuItem("Light", func() {
-			a.Settings().SetTheme(theme.LightTheme())
+			a.Settings().SetTheme(&forceVariantTheme{Theme: catppuccinTheme{}, variant: theme.VariantLight})
 		}),
 		fyne.NewMenuItem("Dark", func() {
-			a.Settings().SetTheme(theme.DarkTheme())
+			a.Settings().SetTheme(&forceVariantTheme{Theme: catppuccinTheme{}, variant: theme.VariantDark})
 		}),
 	)
 
@@ -64,13 +179,19 @@ func RunDesktop() {
 	w.SetMainMenu(mainMenu)
 
 	// Set the welcome title when the app starts
-	welcomeTitleText := getTitle(w, "")
+	welcomeTitleText := getTitle(a, w, "")
 	welcomeTitle := container.NewCenter(welcomeTitleText)
 
 	// Set the welcome text when the app starts
 	// make text light blue, bold and centered with text size of 20.
+	var welcomeTextColor color.Color
+	if a.Settings().ThemeVariant() == theme.VariantLight {
+		welcomeTextColor = getCatppucinColor(catppuccin.Latte.Blue())
+	} else {
+		welcomeTextColor = getCatppucinColor(catppuccin.Mocha.Blue())
+	}
 	welcomeText := canvas.NewText("This is a tool to check DNS records for Microsoft 365.",
-		getCatppucinColor(catppuccin.Mocha.Blue()))
+		welcomeTextColor)
 	welcomeText.Alignment = fyne.TextAlignCenter
 	welcomeText.TextSize = 20.0
 	welcome := container.NewCenter(welcomeText)
@@ -85,12 +206,12 @@ func RunDesktop() {
 	w.ShowAndRun()
 }
 
-func getCNameRecords(w fyne.Window) {
+func getCNameRecords(a fyne.App, w fyne.Window) {
 	// Set up the window for CNAME Records Lookup
-	title := getTitle(w, "CNAME Records")
+	title := getTitle(a, w, "CNAME Records")
 	inputDomain := widget.NewEntry()
 	inputDomain.SetPlaceHolder("Enter the domain you want to check")
-	warning := canvas.NewText("Attention! This can take a long time", color.RGBA{R: 255, G: 0, B: 0, A: 255})
+	warning := canvas.NewText("Attention! This can take a long time", getCatppucinColor(catppuccin.Mocha.Red()))
 	warning.TextStyle.Bold = true
 	placeholder := widget.NewLabel("This is a placeholder")
 	placeholder.Hide()
@@ -113,9 +234,9 @@ func getCNameRecords(w fyne.Window) {
 	w.SetContent(scroll)
 }
 
-func getMX(w fyne.Window) {
+func getMX(a fyne.App, w fyne.Window) {
 	// set up the window for MX Record Lookup
-	title := getTitle(w, "MX Records")
+	title := getTitle(a, w, "MX Records")
 	inputDomain := widget.NewEntry()
 	inputDomain.SetPlaceHolder("Enter the domain you want to check")
 	placeholder := widget.NewLabel("This is a placeholder")
@@ -137,9 +258,9 @@ func getMX(w fyne.Window) {
 	w.SetContent(scroll)
 }
 
-func checkSSL(w fyne.Window) {
+func checkSSL(a fyne.App, w fyne.Window) {
 	// Set up the window for SSL Checker
-	title := getTitle(w, "SSL Checker")
+	title := getTitle(a, w, "SSL Checker")
 	inputDomain := widget.NewEntry()
 	inputDomain.SetPlaceHolder("Enter the domain you want to check - Format: domain.tld:Port")
 	placeholder := widget.NewLabel("This is a placeholder")
@@ -161,9 +282,9 @@ func checkSSL(w fyne.Window) {
 	w.SetContent(scroll)
 }
 
-func getTXT(w fyne.Window) {
+func getTXT(a fyne.App, w fyne.Window) {
 	// set up the window for TXT Record Lookup
-	title := getTitle(w, "TXT Records")
+	title := getTitle(a, w, "TXT Records")
 	inputDomain := widget.NewEntry()
 	inputDomain.SetPlaceHolder("Enter the domain you want to check")
 	placeholder := widget.NewLabel("This is a placeholder")
@@ -185,8 +306,14 @@ func getTXT(w fyne.Window) {
 	w.SetContent(scroll)
 }
 
-func getTitle(w fyne.Window, titleText string) (title *canvas.Text) {
-	blueTitle := getCatppucinColor(catppuccin.Mocha.Blue())
+func getTitle(a fyne.App, w fyne.Window, titleText string) (title *canvas.Text) {
+	// define title color
+	var blueTitle color.Color
+	if a.Settings().ThemeVariant() == theme.VariantLight {
+		blueTitle = getCatppucinColor(catppuccin.Latte.Blue())
+	} else {
+		blueTitle = getCatppucinColor(catppuccin.Mocha.Blue())
+	}
 	// set the title of a window
 	if titleText == "" {
 		w.SetTitle("Go-DNS")


### PR DESCRIPTION
Introduced a new "catppuccin" theme in the application, with both Light and Dark variants. This was done by the addition of a new `catppuccinTheme` type, with the methods to fetch colors and other theme details from the catppuccin color set. Switching between themes has also been enabled in the desktop application menu, replacing the previous default theme. This improves the user interface experience, providing a cohesive and visually pleasing color theme.